### PR TITLE
Use @metrics/metric

### DIFF
--- a/lib/udpd.js
+++ b/lib/udpd.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const EventEmitter = require('events');
-const Metric = require('@metrics/client/lib/metric');
+const Metric = require('@metrics/metric');
 const abslog = require('abslog');
 const dgram = require('dgram');
 

--- a/package.json
+++ b/package.json
@@ -22,10 +22,18 @@
     "url": "https://github.com/metrics-js/daemon/issues"
   },
   "homepage": "https://github.com/metrics-js/daemon#readme",
+  "keywords": [
+    "server-statistics",
+    "server-stats",
+    "statistics",
+    "metrics",
+    "monitoring",
+    "daemon"
+  ],
   "dependencies": {
     "abslog": "^2.2.3",
     "readable-stream": "^3.1.1",
-    "@metrics/client": "^2.2.0"
+    "@metrics/metric": "^1.0.0"
   },
   "devDependencies": {
     "eslint": "^5.10.0",


### PR DESCRIPTION
This uses the `@metrics/metric` module instead of deep diving into the file structure of `@metrics/client`.