### PR TITLE
chore: set up semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release on main
+
+permissions:
+    contents: write # to be able to publish a GitHub release
+    issues: write # to be able to comment on released issues
+    pull-requests: write # to be able to comment on released pull requests
+    id-token: write # to enable use of OIDC for npm provenance
+
+on:
+    push:
+        branches:
+            - main
+
+# Cancel previous workflows which might still be running
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+    release:
+        name: Release
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Install Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 20
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Run all tests
+              run: npm test
+
+            - name: Release and publish
+              run: npx semantic-release
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,27 +1,29 @@
 name: Run Lint and Tests
 
-on: push
+on:
+    pull_request:
+        branches: [main]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [10.x, 12.x, 13.x]
-    steps:
-      - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: npm install
-        run: |
-          npm install
-        env:
-          CI: true
-      - name: Run tests
-        run: |
-          npm run lint && npm test
-        env:
-          CI: true
+    build:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                os: [ubuntu-latest, macOS-latest, windows-latest]
+                node-version: [10.x, 18.x, 20.x]
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Lint
+              run: npm run lint
+
+            - name: Run tests
+              run: npm test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrics/daemon",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Daemon for collecting metrics over misc network protocols. Provides a stream for further piping of metrics.",
   "main": "lib/daemon.js",
   "bin": {
@@ -36,11 +36,18 @@
     "@metrics/metric": "^2.3.1"
   },
   "devDependencies": {
+    "@metrics/client": "2.5.1",
+    "@metrics/emitter": "0.0.2",
+    "@semantic-release/changelog": "6.0.3",
+    "@semantic-release/commit-analyzer": "11.1.0",
+    "@semantic-release/git": "10.0.1",
+    "@semantic-release/github": "9.2.1",
+    "@semantic-release/npm": "11.0.1",
+    "@semantic-release/release-notes-generator": "12.1.0",
     "eslint": "6.8.0",
     "eslint-config-airbnb-base": "14.0.0",
     "eslint-plugin-import": "2.20.0",
-    "tap": "14.11.0",
-    "@metrics/emitter": "0.0.2",
-    "@metrics/client": "2.5.1"
+    "semantic-release": "22.0.7",
+    "tap": "14.11.0"
   }
 }

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,27 @@
+module.exports = {
+    plugins: [
+        '@semantic-release/commit-analyzer',
+        '@semantic-release/release-notes-generator',
+        '@semantic-release/changelog',
+        [
+            '@semantic-release/npm',
+            {
+                tarballDir: 'release',
+            },
+        ],
+        [
+            '@semantic-release/github',
+            {
+                assets: 'release/*.tgz',
+            },
+        ],
+        '@semantic-release/git',
+    ],
+    preset: 'angular',
+    branches: [
+        { name: 'main' },
+        { name: 'alpha', prerelease: true },
+        { name: 'beta', prerelease: true },
+        { name: 'next', prerelease: true },
+    ],
+};


### PR DESCRIPTION
Automate releases

Set to 1.0.0, semantic-release doesn't support lower